### PR TITLE
Add compile option `ABC_USE_SYSTEM_ZLIB`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,12 @@ if( APPLE )
     set(make_env ${CMAKE_COMMAND} -E env SDKROOT=${CMAKE_OSX_SYSROOT})
 endif()
 
+if(ABC_USE_SYSTEM_ZLIB)
+    message("Using system zlib.")
+    find_package(ZLIB)
+    set(ABC_USE_SYSTEM_ZLIB_FLAGS "ABC_USE_SYSTEM_ZLIB=${ABC_USE_SYSTEM_ZLIB}")
+endif()
+
 # run make to extract compiler options, linker options and list of source files
 execute_process(
   COMMAND
@@ -65,6 +71,7 @@ execute_process(
         ${ABC_READLINE_FLAGS}
         ${ABC_USE_NAMESPACE_FLAGS}
         ${ABC_USE_STDINT_H_FLAGS}
+        ${ABC_USE_SYSTEM_ZLIB_FLAGS}
         ARCHFLAGS_EXE=${CMAKE_CURRENT_BINARY_DIR}/abc_arch_flags_program.exe
         ABC_MAKE_NO_DEPS=1
         CC=${CMAKE_C_COMPILER}
@@ -98,6 +105,9 @@ function(abc_properties target visibility)
     target_include_directories(${target} ${visibility} ${CMAKE_CURRENT_SOURCE_DIR}/src )
     target_compile_options_filtered(${target} ${visibility} ${ABC_CFLAGS} ${ABC_CXXFLAGS} -Wno-unused-but-set-variable )
     target_link_libraries(${target} ${visibility} ${ABC_LIBS})
+    if(ABC_USE_SYSTEM_ZLIB)
+        target_link_libraries(${target} ${visibility} ZLIB::ZLIB)
+    endif()
 endfunction()
 
 set(ABC_MAIN_SRC src/base/main/main.c)

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ MODULES := \
 	src/map/mapper src/map/mio src/map/super src/map/if \
 	src/map/amap src/map/cov src/map/scl src/map/mpm \
 	src/misc/extra src/misc/mvc src/misc/st src/misc/util src/misc/nm \
-	src/misc/vec src/misc/hash src/misc/tim src/misc/bzlib src/misc/zlib \
+	src/misc/vec src/misc/hash src/misc/tim src/misc/bzlib \
 	src/misc/mem src/misc/bar src/misc/bbl src/misc/parse \
 	src/opt/cut src/opt/fxu src/opt/fxch src/opt/rwr src/opt/mfs src/opt/sim \
 	src/opt/ret src/opt/fret src/opt/res src/opt/lpk src/opt/nwk src/opt/rwt \
@@ -34,6 +34,10 @@ MODULES := \
 	src/proof/cec src/proof/acec src/proof/dch src/proof/fraig src/proof/fra src/proof/ssw \
 	src/aig/aig src/aig/saig src/aig/gia src/aig/ioa src/aig/ivy src/aig/hop \
 	src/aig/miniaig
+
+ifndef ABC_USE_SYSTEM_ZLIB
+MODULES += src/misc/zlib
+endif
 
 all: $(PROG)
 default: $(PROG)


### PR DESCRIPTION
This adds a compile option to use the system zlib in place of the included `src/misc/zlib` when compiling libabc standalone.

Explanation:

https://github.com/The-OpenROAD-Project/OpenROAD/issues/3108#issuecomment-1489412330