### PR TITLE
bazel/macos: migrate zlib and readline from rules_hdl to bazel repo

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1454,8 +1454,8 @@ cc_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
-        "@org_gnu_readline//:readline",
-        "@net_zlib//:zlib",
+        "@readline//:readline",
+        "@zlib//:zlib",
         # FIXME: This needs bz2lib?
     ],
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -15,3 +15,6 @@ use_repo(llvm, "llvm_toolchain")
 register_toolchains(
     "@llvm_toolchain//:all",
 )
+
+bazel_dep(name = "zlib", version = "1.3.1.bcr.5")
+bazel_dep(name = "readline", version = "8.3")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -19,11 +19,6 @@ http_archive(
 )
 
 load("@rules_hdl//dependency_support/net_invisible_island_ncurses:net_invisible_island_ncurses.bzl", "net_invisible_island_ncurses")
-load("@rules_hdl//dependency_support/net_zlib:net_zlib.bzl", "net_zlib")
-load("@rules_hdl//dependency_support/org_gnu_readline:org_gnu_readline.bzl", "org_gnu_readline")
 
 net_invisible_island_ncurses()
 
-net_zlib()
-
-org_gnu_readline()


### PR DESCRIPTION
For MacOS compatibility i used the zlib and readline libraries from the bazel repository. This is probably obsolete if the BCR abc is used. Anyway i had this fixed already. 

This belongs to the bazel/macos fixes including the tcl migration: https://github.com/The-OpenROAD-Project/OpenROAD/pull/9480